### PR TITLE
breaking: drop npm 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ notifications:
   email: false
 node_js:
   - '8'
-  - '4'
+  - '6'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # eslint-config-callstack-io
 
-Callstack.io eslint config utilizing Airbnb config, Flow, Prettier and Jest support.
+Callstack eslint config utilizing Airbnb config, Flow, Prettier and Jest support.
 
 Plugins and configs used:
 * [eslint-config-airbnb](https://yarnpkg.com/en/package/eslint-config-airbnb)
@@ -34,7 +34,7 @@ And for test files matching default Jest `testMatch`:
 yarn add --dev eslint eslint-config-callstack-io
 ```
 
-*Note: We're using `yarn` to install deps. Feel free to change commands to use `npm` and `npx` if you like*
+*Note: We're using `yarn` to install deps. Feel free to change commands to use `npm` 3+ and `npx` if you like*
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "eslint-config-callstack-io",
-  "version": "0.0.0-development",
+  "version": "0.5.0",
   "description": "ESLint preset extending Airbnb, Flow, Prettier and Jest",
   "main": "index.js",
-  "repository": "git@github.com:callstack-io/eslint-config-callstack-io.git",
+  "repository": "git@github.com:callstack/eslint-config-callstack-io.git",
   "author": "Michał Pierzchała <thymikee@gmail.com>",
   "license": "MIT",
   "keywords": [
     "eslint",
-    "eslintconfig",
-    "callstack-io"
+    "eslint config",
+    "callstack"
   ],
   "dependencies": {
     "babel-eslint": "^7.2.3",
@@ -24,17 +24,6 @@
     "prettier": "^1.5.3"
   },
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
-    "eslint": ">=4",
-    "eslint-config-airbnb": "^15.1.0",
-    "eslint-config-prettier": "^2.3.0",
-    "eslint-plugin-flowtype": "^2.35.0",
-    "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jest": "^20.0.3",
-    "eslint-plugin-jsx-a11y": "^5.1.1",
-    "eslint-plugin-prettier": "^2.1.2",
-    "eslint-plugin-react": "^7.1.0",
-    "eslint-restricted-globals": "^0.1.1",
-    "prettier": "^1.5.3"
+    "eslint": ">=4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,8 +202,8 @@ eslint-config-airbnb@^15.1.0:
     eslint-config-airbnb-base "^11.3.0"
 
 eslint-config-prettier@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.3.0.tgz#b75b1eabea0c8b97b34403647ee25db349b9d8a0"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
   dependencies:
     get-stdin "^5.0.1"
 
@@ -494,8 +494,8 @@ pkg-dir@^1.0.0:
     find-up "^1.0.0"
 
 prettier@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We don't use npm 2 anywhere and it's about to get it's EOL soon. And missing peerDependencies in regular projects that use this config make Yarn (and probably npm 3+ too) unhappy.

Also, I'm tempted to remove semantic-release because it doesn't bump the version in `package.json`. It also released `0.5.0` to NPM registry without a git tag nor a changelog (here's link to some [weird errors](https://travis-ci.org/callstack/eslint-config-callstack-io/jobs/286465873) from CI)