### PR TITLE
breaking: bump Prettier to 1.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "eslint-config-airbnb": "^15.1.0",
-    "eslint-config-prettier": "^2.3.0",
+    "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.1.0",
-    "prettier": "^1.5.3"
+    "prettier": "^1.7.4"
   },
   "peerDependencies": {
     "eslint": ">=4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,7 +201,7 @@ eslint-config-airbnb@^15.1.0:
   dependencies:
     eslint-config-airbnb-base "^11.3.0"
 
-eslint-config-prettier@^2.3.0:
+eslint-config-prettier@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.6.0.tgz#f21db0ebb438ad678fb98946097c4bb198befccc"
   dependencies:
@@ -493,7 +493,7 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
-prettier@^1.5.3:
+prettier@^1.7.4:
   version "1.7.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 


### PR DESCRIPTION
This changes a lot in formatting React components, so tagging it as breaking.