### PR TITLE
Remove class-methods-use-this rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
   parser: 'babel-eslint',
   plugins: ['flowtype', 'jest', 'prettier'],
   rules: {
+    'class-methods-use-this': 0,
     'flowtype/no-weak-types': 1,
     'flowtype/require-parameter-type': 0,
     'flowtype/require-return-type': [0, 'always', {annotateUndefined: 'never'}],


### PR DESCRIPTION
Due to usage of [`componentDidCatch()`](https://reactjs.org/blog/2017/07/26/error-handling-in-react-16.html) in React 16, we should rather disable this rule. Often you don't need to use this in following class method.