### PR TITLE
fix: add __mocks__ for jest

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,11 @@ module.exports = {
     'react/sort-comp': 0
   },
   overrides: {
-    files: ['**/__tests__/**/*.js?(x)', '**/?(*.)(spec|test).js?(x)'],
+    files: [
+      '**/__tests__/**/*.js?(x)',
+      '**/__mocks__/**/*.js?(x)', 
+      '**/?(*.)(spec|test).js?(x)'
+    ],
     env: {
       'jest/globals': true
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-flowtype": "^2.35.0",
     "eslint-plugin-import": "^2.7.0",
-    "eslint-plugin-jest": "^20.0.3",
+    "eslint-plugin-jest": "^21.17.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-prettier": "^2.1.2",
     "eslint-plugin-react": "^7.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -422,9 +422,9 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jest@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-20.0.3.tgz#ec15eba6ac0ab44a67ebf6e02672ca9d7e7cba29"
+eslint-plugin-jest@^21.17.0:
+  version "21.17.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-21.17.0.tgz#fdb00e2f9ff16987d6ebcf2c75c7add105760bbb"
 
 eslint-plugin-jsx-a11y@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Right now eslint won't detect `jest` inside `__mocks__`.